### PR TITLE
feat(mobile): Issues 5, 6, 7, 10 — price alerts, order notifications, recurring order inbox

### DIFF
--- a/app/src/main/java/rs/raf/banka1/mobile/core/di/NetworkModule.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/core/di/NetworkModule.kt
@@ -22,6 +22,7 @@ import rs.raf.banka1.mobile.data.apis.CardApi
 import rs.raf.banka1.mobile.data.apis.ClientApi
 import rs.raf.banka1.mobile.data.apis.ExchangeApi
 import rs.raf.banka1.mobile.data.apis.ListingApi
+import rs.raf.banka1.mobile.data.apis.LoanApi
 import rs.raf.banka1.mobile.data.apis.OrderApi
 import rs.raf.banka1.mobile.data.apis.PriceAlertApi
 import rs.raf.banka1.mobile.data.apis.TransactionApi
@@ -150,6 +151,12 @@ object NetworkModule {
     @Provides
     fun providePriceAlertApi(retrofit: Retrofit): PriceAlertApi {
         return retrofit.create(PriceAlertApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideLoanApi(retrofit: Retrofit): LoanApi {
+        return retrofit.create(LoanApi::class.java)
     }
 
     @Singleton

--- a/app/src/main/java/rs/raf/banka1/mobile/core/di/NetworkModule.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/core/di/NetworkModule.kt
@@ -21,7 +21,9 @@ import rs.raf.banka1.mobile.data.apis.AuthApi
 import rs.raf.banka1.mobile.data.apis.CardApi
 import rs.raf.banka1.mobile.data.apis.ClientApi
 import rs.raf.banka1.mobile.data.apis.ExchangeApi
+import rs.raf.banka1.mobile.data.apis.ListingApi
 import rs.raf.banka1.mobile.data.apis.OrderApi
+import rs.raf.banka1.mobile.data.apis.PriceAlertApi
 import rs.raf.banka1.mobile.data.apis.TransactionApi
 import rs.raf.banka1.mobile.data.apis.TransferApi
 import rs.raf.banka1.mobile.data.apis.NotificationApi
@@ -142,5 +144,17 @@ object NetworkModule {
     @Provides
     fun provideOrderApi(retrofit: Retrofit): OrderApi {
         return retrofit.create(OrderApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun providePriceAlertApi(retrofit: Retrofit): PriceAlertApi {
+        return retrofit.create(PriceAlertApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideListingApi(retrofit: Retrofit): ListingApi {
+        return retrofit.create(ListingApi::class.java)
     }
 }

--- a/app/src/main/java/rs/raf/banka1/mobile/core/push/BankMessagingService.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/core/push/BankMessagingService.kt
@@ -112,9 +112,14 @@ class BankMessagingService : FirebaseMessagingService() {
     }
 
     private fun handleOrderNotification(type: String, data: Map<String, String>) {
-        val title = data["title"]?.takeIf { it.isNotBlank() } ?: "Obavestenje o nalogu"
-        val body = data["body"]?.takeIf { it.isNotBlank() }
-            ?: ("Status naloga: " + (data["status"] ?: ""))
+        val title = data["title"]?.takeIf { it.isNotBlank() } ?: when (type) {
+            "ORDER_RECURRING_SKIPPED" -> "Periodicni nalog preskocen"
+            else -> "Obavestenje o nalogu"
+        }
+        val body = data["body"]?.takeIf { it.isNotBlank() } ?: when (type) {
+            "ORDER_RECURRING_SKIPPED" -> "Vas periodicni nalog nije izvrsen zbog nedovoljnih sredstava."
+            else -> "Status naloga: " + (data["status"] ?: "")
+        }
         val orderId = data["orderId"]?.toLongOrNull()
         val now = System.currentTimeMillis()
 

--- a/app/src/main/java/rs/raf/banka1/mobile/data/apis/CardApi.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/apis/CardApi.kt
@@ -19,6 +19,11 @@ interface CardApi {
         @Path("cardNumber") cardNumber: String
     ): NetworkResult<CardDetailDto>
 
+    @GET("api/cards/id/{cardId}")
+    suspend fun getCardById(
+        @Path("cardId") cardId: Long
+    ): NetworkResult<CardDetailDto>
+
     @PUT("api/cards/id/{cardId}/block")
     suspend fun blockCard(
         @Path("cardId") cardId: Long

--- a/app/src/main/java/rs/raf/banka1/mobile/data/apis/CardApi.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/apis/CardApi.kt
@@ -1,6 +1,7 @@
 package rs.raf.banka1.mobile.data.apis
 
 import retrofit2.http.GET
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import rs.raf.banka1.mobile.data.remote.NetworkResult
 import rs.raf.banka1.mobile.data.remote.responses.CardDetailDto
@@ -17,4 +18,9 @@ interface CardApi {
     suspend fun getCardDetails(
         @Path("cardNumber") cardNumber: String
     ): NetworkResult<CardDetailDto>
+
+    @PUT("api/cards/id/{cardId}/block")
+    suspend fun blockCard(
+        @Path("cardId") cardId: Long
+    ): NetworkResult<Unit>
 }

--- a/app/src/main/java/rs/raf/banka1/mobile/data/apis/ExchangeApi.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/apis/ExchangeApi.kt
@@ -17,6 +17,13 @@ interface ExchangeApi {
         @Path("currencyCode") currencyCode: String
     ): NetworkResult<ExchangeRateDto>
 
+    @GET("exchange/rates/{currencyCode}/history")
+    suspend fun getRateHistory(
+        @Path("currencyCode") currencyCode: String,
+        @Query("from") from: String,
+        @Query("to") to: String
+    ): NetworkResult<List<ExchangeRateDto>>
+
     @GET("exchange/calculate")
     suspend fun calculateConversion(
         @Query("fromCurrency") fromCurrency: String,

--- a/app/src/main/java/rs/raf/banka1/mobile/data/apis/ListingApi.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/apis/ListingApi.kt
@@ -1,0 +1,27 @@
+package rs.raf.banka1.mobile.data.apis
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+import rs.raf.banka1.mobile.data.remote.NetworkResult
+import rs.raf.banka1.mobile.data.remote.responses.ListingDetailsDto
+import rs.raf.banka1.mobile.data.remote.responses.ListingSummaryDto
+import rs.raf.banka1.mobile.data.remote.responses.PageResponse
+
+interface ListingApi {
+
+    @GET("stock/api/listings/stocks")
+    suspend fun searchStocks(
+        @Query("search") q: String? = null,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 20,
+        @Query("sortBy") sortBy: String = "ticker",
+        @Query("sortDirection") dir: String = "asc"
+    ): NetworkResult<PageResponse<ListingSummaryDto>>
+
+    @GET("stock/api/listings/{id}")
+    suspend fun getDetails(
+        @Path("id") id: Long,
+        @Query("period") period: String = "DAY"
+    ): NetworkResult<ListingDetailsDto>
+}

--- a/app/src/main/java/rs/raf/banka1/mobile/data/apis/LoanApi.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/apis/LoanApi.kt
@@ -1,0 +1,16 @@
+package rs.raf.banka1.mobile.data.apis
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+import rs.raf.banka1.mobile.data.remote.NetworkResult
+import rs.raf.banka1.mobile.data.remote.responses.LoanResponseDto
+import rs.raf.banka1.mobile.data.remote.responses.PageResponse
+
+interface LoanApi {
+
+    @GET("api/loans/client")
+    suspend fun getClientLoans(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 100
+    ): NetworkResult<PageResponse<LoanResponseDto>>
+}

--- a/app/src/main/java/rs/raf/banka1/mobile/data/apis/PriceAlertApi.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/apis/PriceAlertApi.kt
@@ -1,0 +1,26 @@
+package rs.raf.banka1.mobile.data.apis
+
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import rs.raf.banka1.mobile.data.remote.NetworkResult
+import rs.raf.banka1.mobile.data.remote.requests.CreatePriceAlertRequest
+import rs.raf.banka1.mobile.data.remote.responses.PriceAlertDto
+
+interface PriceAlertApi {
+
+    @GET("price-alerts")
+    suspend fun getMyAlerts(): NetworkResult<List<PriceAlertDto>>
+
+    @POST("price-alerts")
+    suspend fun create(@Body req: CreatePriceAlertRequest): NetworkResult<PriceAlertDto>
+
+    @PATCH("price-alerts/{id}")
+    suspend fun toggle(@Path("id") id: Long): NetworkResult<PriceAlertDto>
+
+    @DELETE("price-alerts/{id}")
+    suspend fun delete(@Path("id") id: Long): NetworkResult<Unit>
+}

--- a/app/src/main/java/rs/raf/banka1/mobile/data/remote/requests/CreatePriceAlertRequest.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/remote/requests/CreatePriceAlertRequest.kt
@@ -1,0 +1,19 @@
+package rs.raf.banka1.mobile.data.remote.requests
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class CreatePriceAlertRequest(
+    @field:Json(name = "listingId")
+    val listingId: Long,
+
+    @field:Json(name = "condition")
+    val condition: String,
+
+    @field:Json(name = "threshold")
+    val threshold: Double,
+
+    @field:Json(name = "notificationType")
+    val notificationType: String
+)

--- a/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/CardDtos.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/CardDtos.kt
@@ -5,6 +5,9 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class CardSummaryDto(
+    @field:Json(name = "id")
+    val id: Long? = null,
+
     @field:Json(name = "maskedCardNumber")
     val maskedCardNumber: String? = null,
 
@@ -14,6 +17,9 @@ data class CardSummaryDto(
 
 @JsonClass(generateAdapter = true)
 data class CardDetailDto(
+    @field:Json(name = "id")
+    val id: Long? = null,
+
     @field:Json(name = "cardNumber")
     val cardNumber: String? = null,
 

--- a/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/ListingDetailsDto.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/ListingDetailsDto.kt
@@ -1,0 +1,25 @@
+package rs.raf.banka1.mobile.data.remote.responses
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ListingDetailsDto(
+    @field:Json(name = "listingId")
+    val listingId: Long? = null,
+
+    @field:Json(name = "ticker")
+    val ticker: String? = null,
+
+    @field:Json(name = "name")
+    val name: String? = null,
+
+    @field:Json(name = "price")
+    val price: Double? = null,
+
+    @field:Json(name = "currency")
+    val currency: String? = null,
+
+    @field:Json(name = "changePercent")
+    val changePercent: Double? = null
+)

--- a/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/ListingSummaryDto.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/ListingSummaryDto.kt
@@ -1,0 +1,31 @@
+package rs.raf.banka1.mobile.data.remote.responses
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ListingSummaryDto(
+    @field:Json(name = "listingId")
+    val listingId: Long? = null,
+
+    @field:Json(name = "ticker")
+    val ticker: String? = null,
+
+    @field:Json(name = "name")
+    val name: String? = null,
+
+    @field:Json(name = "currency")
+    val currency: String? = null,
+
+    @field:Json(name = "price")
+    val price: Double? = null,
+
+    @field:Json(name = "change")
+    val change: Double? = null,
+
+    @field:Json(name = "volume")
+    val volume: Long? = null,
+
+    @field:Json(name = "listingType")
+    val listingType: String? = null
+)

--- a/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/LoanDtos.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/LoanDtos.kt
@@ -1,0 +1,22 @@
+package rs.raf.banka1.mobile.data.remote.responses
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class LoanResponseDto(
+    @field:Json(name = "loanNumber") val loanNumber: Long? = null,
+    @field:Json(name = "loanType") val loanType: String? = null,
+    @field:Json(name = "accountNumber") val accountNumber: String? = null,
+    @field:Json(name = "amount") val amount: Double? = null,
+    @field:Json(name = "repaymentMethod") val repaymentMethod: Int? = null,
+    @field:Json(name = "nominalInterestRate") val nominalInterestRate: Double? = null,
+    @field:Json(name = "effectiveInterestRate") val effectiveInterestRate: Double? = null,
+    @field:Json(name = "interestType") val interestType: String? = null,
+    @field:Json(name = "agreementDate") val agreementDate: String? = null,
+    @field:Json(name = "maturityDate") val maturityDate: String? = null,
+    @field:Json(name = "installmentAmount") val installmentAmount: Double? = null,
+    @field:Json(name = "nextInstallmentDate") val nextInstallmentDate: String? = null,
+    @field:Json(name = "remainingDebt") val remainingDebt: Double? = null,
+    @field:Json(name = "status") val status: String? = null
+)

--- a/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/PriceAlertDto.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/data/remote/responses/PriceAlertDto.kt
@@ -1,0 +1,31 @@
+package rs.raf.banka1.mobile.data.remote.responses
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PriceAlertDto(
+    @field:Json(name = "id")
+    val id: Long? = null,
+
+    @field:Json(name = "listingId")
+    val listingId: Long? = null,
+
+    @field:Json(name = "condition")
+    val condition: String? = null,
+
+    @field:Json(name = "threshold")
+    val threshold: Double? = null,
+
+    @field:Json(name = "notificationType")
+    val notificationType: String? = null,
+
+    @field:Json(name = "active")
+    val active: Boolean = false,
+
+    @field:Json(name = "createdAt")
+    val createdAt: String? = null,
+
+    @field:Json(name = "lastTriggeredAt")
+    val lastTriggeredAt: String? = null
+)

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/components/NavigationDrawer.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/components/NavigationDrawer.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBalance
+import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.CurrencyExchange
 import androidx.compose.material.icons.filled.Home
@@ -68,6 +69,7 @@ enum class DrawerMenuItem(
     IPS_PAYMENTS(Icons.Default.QrCode, "IPS Plaćanja", Routes.MainFlow.IpsHub),
     HISTORY(Icons.Default.Receipt, "Istorija", Routes.MainFlow.History),
     MY_ORDERS(Icons.AutoMirrored.Filled.ShowChart, "Moji nalozi", Routes.MainFlow.MyOrders),
+    LOANS(Icons.Default.AccountBalanceWallet, "Krediti", Routes.MainFlow.Loans),
     NOTIFICATIONS(Icons.Default.Notifications, "Obavestenja", Routes.MainFlow.Notifications),
     EXCHANGE(Icons.Default.CurrencyExchange, "Menjacnica", Routes.MainFlow.Exchange),
     VERIFICATION(Icons.Default.VerifiedUser, "Verifikacija", Routes.MainFlow.Verification),

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/components/NavigationDrawer.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/components/NavigationDrawer.kt
@@ -67,7 +67,7 @@ enum class DrawerMenuItem(
     ACCOUNTS(Icons.Default.AccountBalance, "Racuni i kartice", Routes.MainFlow.Accounts),
     PAYMENTS(Icons.Default.Payment, "Placanja", Routes.MainFlow.Payments()),
     IPS_PAYMENTS(Icons.Default.QrCode, "IPS Plaćanja", Routes.MainFlow.IpsHub),
-    HISTORY(Icons.Default.Receipt, "Istorija", Routes.MainFlow.History),
+    HISTORY(Icons.Default.Receipt, "Istorija", Routes.MainFlow.History()),
     MY_ORDERS(Icons.AutoMirrored.Filled.ShowChart, "Moji nalozi", Routes.MainFlow.MyOrders),
     LOANS(Icons.Default.AccountBalanceWallet, "Krediti", Routes.MainFlow.Loans),
     NOTIFICATIONS(Icons.Default.Notifications, "Obavestenja", Routes.MainFlow.Notifications),

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/RootNavGraph.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/RootNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -202,11 +203,19 @@ fun RootNavGraph(
                         },
                         actions = {
                             val onScan = topBarScanAction.value
-                            when {
-                                isOnDashboard -> IpsTopBarAction(
+                            if (isOnDashboard) {
+                                IconButton(onClick = { navController.navigate(Routes.MainFlow.Notifications) }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Notifications,
+                                        contentDescription = "Obavestenja",
+                                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                }
+                                IpsTopBarAction(
                                     onClick = { navController.navigate(Routes.MainFlow.IpsHub) }
                                 )
-                                onScan != null -> IpsTopBarAction(onClick = onScan)
+                            } else if (onScan != null) {
+                                IpsTopBarAction(onClick = onScan)
                             }
                         },
                         colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
@@ -50,6 +50,9 @@ object Routes {
         data object MyOrders : MainFlow
 
         @Serializable
+        data object Loans : MainFlow
+
+        @Serializable
         data object Notifications : MainFlow
 
         @Serializable

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
@@ -32,7 +32,7 @@ object Routes {
         data class AccountDetail(val accountNumber: String) : MainFlow
 
         @Serializable
-        data class CardDetail(val accountNumber: String, val cardNumber: String) : MainFlow
+        data class CardDetail(val accountNumber: String, val cardNumber: String, val cardId: Long = 0L) : MainFlow
 
         @Serializable
         data object Transfers : MainFlow

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
@@ -44,7 +44,10 @@ object Routes {
         data object IpsHub : MainFlow
 
         @Serializable
-        data object History : MainFlow
+        data class History(
+            val accountNumber: String? = null,
+            val cardLabel: String? = null
+        ) : MainFlow
 
         @Serializable
         data object MyOrders : MainFlow

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/Routes.kt
@@ -53,6 +53,9 @@ object Routes {
         data object Notifications : MainFlow
 
         @Serializable
+        data object PriceAlerts : MainFlow
+
+        @Serializable
         data class TransferDetail(
             val orderNumber: String,
             val fromCurrency: String,

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
@@ -24,6 +24,7 @@ import rs.raf.banka1.mobile.presentation.screens.history.TransferDetailScreen
 import rs.raf.banka1.mobile.presentation.screens.main.VerificationScreen
 import rs.raf.banka1.mobile.presentation.screens.ips.IpsHubScreen
 import rs.raf.banka1.mobile.presentation.screens.notifications.NotificationsScreen
+import rs.raf.banka1.mobile.presentation.screens.loans.LoansScreen
 import rs.raf.banka1.mobile.presentation.screens.orders.MyOrdersScreen
 import rs.raf.banka1.mobile.presentation.screens.pricealerts.PriceAlertsScreen
 import rs.raf.banka1.mobile.presentation.screens.payments.PaymentScreen
@@ -211,6 +212,13 @@ fun NavGraphBuilder.mainNavGraph(navController: NavController) {
         composable<Routes.MainFlow.MyOrders> {
             MyOrdersScreen(
                 viewModel = hiltViewModel()
+            )
+        }
+
+        composable<Routes.MainFlow.Loans> {
+            LoansScreen(
+                viewModel = hiltViewModel(),
+                onNavigateBack = { navController.popBackStack() }
             )
         }
 

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
@@ -104,9 +104,9 @@ fun NavGraphBuilder.mainNavGraph(navController: NavController) {
                         launchSingleTop = true
                     }
                 },
-                onNavigateToCardDetail = { accountNumber, cardNumber ->
+                onNavigateToCardDetail = { accountNumber, cardNumber, cardId ->
                     navController.navigate(
-                        Routes.MainFlow.CardDetail(accountNumber, cardNumber)
+                        Routes.MainFlow.CardDetail(accountNumber, cardNumber, cardId)
                     ) {
                         launchSingleTop = true
                     }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
@@ -135,7 +135,12 @@ fun NavGraphBuilder.mainNavGraph(navController: NavController) {
         composable<Routes.MainFlow.CardDetail> {
             CardDetailScreen(
                 viewModel = hiltViewModel(),
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToCardHistory = { accountNumber, cardLabel ->
+                    navController.navigate(
+                        Routes.MainFlow.History(accountNumber, cardLabel)
+                    ) { launchSingleTop = true }
+                }
             )
         }
 
@@ -178,18 +183,21 @@ fun NavGraphBuilder.mainNavGraph(navController: NavController) {
                     }
                 },
                 onNavigateToTransactionDetail = { transaction ->
-                    // Create a Moshi instance (or use Gson().toJson(transaction))
                     val moshi = Moshi.Builder()
                         .add(KotlinJsonAdapterFactory())
                         .build()
 
                     val json = moshi.adapter(TransactionResponseDto::class.java).toJson(transaction)
-
-                    // Encode the JSON to be safe for URI paths
                     val encodedJson = Uri.encode(json)
 
                     navController.navigate(Routes.MainFlow.TransactionDetail(encodedJson)) {
                         launchSingleTop = true
+                    }
+                },
+                onClearFilter = {
+                    navController.navigate(Routes.MainFlow.History()) {
+                        launchSingleTop = true
+                        popUpTo(Routes.MainFlow.History::class) { inclusive = true }
                     }
                 }
             )

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/navigation/SubNavGraphs.kt
@@ -25,6 +25,7 @@ import rs.raf.banka1.mobile.presentation.screens.main.VerificationScreen
 import rs.raf.banka1.mobile.presentation.screens.ips.IpsHubScreen
 import rs.raf.banka1.mobile.presentation.screens.notifications.NotificationsScreen
 import rs.raf.banka1.mobile.presentation.screens.orders.MyOrdersScreen
+import rs.raf.banka1.mobile.presentation.screens.pricealerts.PriceAlertsScreen
 import rs.raf.banka1.mobile.presentation.screens.payments.PaymentScreen
 import rs.raf.banka1.mobile.presentation.screens.profile.ProfileScreen
 
@@ -220,7 +221,19 @@ fun NavGraphBuilder.mainNavGraph(navController: NavController) {
                     navController.navigate(Routes.MainFlow.MyOrders) {
                         launchSingleTop = true
                     }
+                },
+                onNavigateToPriceAlerts = {
+                    navController.navigate(Routes.MainFlow.PriceAlerts) {
+                        launchSingleTop = true
+                    }
                 }
+            )
+        }
+
+        composable<Routes.MainFlow.PriceAlerts> {
+            PriceAlertsScreen(
+                viewModel = hiltViewModel(),
+                onNavigateBack = { navController.popBackStack() }
             )
         }
 

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/accounts/AccountsCardsScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/accounts/AccountsCardsScreen.kt
@@ -100,7 +100,7 @@ private val currencySymbols = mapOf(
 fun AccountsCardsScreen(
     viewModel: AccountsCardsViewModel,
     onNavigateToAccountDetail: (String) -> Unit,
-    onNavigateToCardDetail: (String, String) -> Unit
+    onNavigateToCardDetail: (String, String, Long) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val onEvent = viewModel::setEvent
@@ -235,8 +235,8 @@ fun AccountsCardsScreen(
                     } else {
                         CardsList(
                             cards = state.cards,
-                            onCardClick = { accountNumber, cardNumber ->
-                                onNavigateToCardDetail(accountNumber, cardNumber)
+                            onCardClick = { accountNumber, cardNumber, cardId ->
+                                onNavigateToCardDetail(accountNumber, cardNumber, cardId)
                             }
                         )
                     }
@@ -415,7 +415,7 @@ private fun AccountCard(
 @Composable
 private fun CardsList(
     cards: List<CardWithAccount>,
-    onCardClick: (String, String) -> Unit
+    onCardClick: (String, String, Long) -> Unit
 ) {
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
@@ -447,7 +447,8 @@ private fun CardsList(
                     onClick = {
                         onCardClick(
                             cardWithAccount.card.accountNumber ?: "",
-                            cardWithAccount.card.cardNumber ?: ""
+                            cardWithAccount.card.cardNumber ?: "",
+                            cardWithAccount.card.id ?: 0L
                         )
                     }
                 )

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/accounts/AccountsCardsScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/accounts/AccountsCardsScreen.kt
@@ -105,6 +105,10 @@ fun AccountsCardsScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val onEvent = viewModel::setEvent
 
+    LaunchedEffect(Unit) {
+        viewModel.loadData()
+    }
+
     if (state.error != null) {
         ErrorDialog(errorData = state.error) {
             onEvent(AccountsCardsContract.UiEvent.ClearError)
@@ -545,17 +549,19 @@ private fun CardItem(
             }
 
             Column(horizontalAlignment = Alignment.End) {
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(statusColor.copy(alpha = 0.12f))
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                ) {
-                    Text(
-                        text = cardStatusLabels[status] ?: status,
-                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
-                        color = statusColor
-                    )
+                if (card.status != null) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(statusColor.copy(alpha = 0.12f))
+                            .padding(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Text(
+                            text = cardStatusLabels[status] ?: status,
+                            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                            color = statusColor
+                        )
+                    }
                 }
 
                 if (card.expiryDate != null) {

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/cards/CardDetailScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/cards/CardDetailScreen.kt
@@ -23,8 +23,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountBalance
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.CreditCard
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -34,6 +38,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -71,6 +76,40 @@ fun CardDetailScreen(
         ErrorDialog(errorData = state.error) {
             viewModel.setEvent(CardDetailContract.UiEvent.ClearError)
         }
+    }
+
+    if (state.showBlockDialog) {
+        AlertDialog(
+            onDismissRequest = { viewModel.setEvent(CardDetailContract.UiEvent.DismissBlockDialog) },
+            title = { Text("Blokiraj karticu") },
+            text = {
+                Text("Da li ste sigurni da želite da blokirate ovu karticu? Odblokiranje je moguće samo lično u ekspozituri ili pozivom korisničkoj podršci.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.setEvent(CardDetailContract.UiEvent.BlockCard) },
+                    enabled = !state.isBlocking
+                ) {
+                    if (state.isBlocking) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    } else {
+                        Text("Blokiraj", color = MaterialTheme.colorScheme.error)
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { viewModel.setEvent(CardDetailContract.UiEvent.DismissBlockDialog) },
+                    enabled = !state.isBlocking
+                ) {
+                    Text("Otkaži")
+                }
+            }
+        )
     }
 
     Scaffold(
@@ -112,7 +151,8 @@ fun CardDetailScreen(
             } else if (state.card != null) {
                 CardDetailContent(
                     card = state.card!!,
-                    account = state.account
+                    account = state.account,
+                    onBlockClick = { viewModel.setEvent(CardDetailContract.UiEvent.ShowBlockDialog) }
                 )
             }
         }
@@ -122,7 +162,8 @@ fun CardDetailScreen(
 @Composable
 private fun CardDetailContent(
     card: CardResponseDto,
-    account: AccountDetailsResponseDto?
+    account: AccountDetailsResponseDto?,
+    onBlockClick: () -> Unit
 ) {
     val animProgress = remember { Animatable(0f) }
     LaunchedEffect(Unit) {
@@ -193,7 +234,64 @@ private fun CardDetailContent(
                 }
             }
 
+            // Block action section
+            CardBlockSection(card = card, onBlockClick = onBlockClick)
+
             Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun CardBlockSection(
+    card: CardResponseDto,
+    onBlockClick: () -> Unit
+) {
+    val status = card.status ?: ""
+    val isActive = status == "ACTIVE" || status == "ACTIVATED"
+    val isBlocked = status == "BLOCKED"
+
+    if (!isActive && !isBlocked) return
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (isActive) {
+            Button(
+                onClick = onBlockClick,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Block,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Blokiraj karticu")
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
+                .padding(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(16.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = "Odblokiranje je moguće samo lično u ekspozituri ili pozivom korisničkoj podršci.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/cards/CardDetailScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/cards/CardDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -68,7 +69,8 @@ import kotlin.math.roundToInt
 @Composable
 fun CardDetailScreen(
     viewModel: CardDetailViewModel,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onNavigateToCardHistory: (accountNumber: String, cardLabel: String) -> Unit = { _, _ -> }
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -152,7 +154,8 @@ fun CardDetailScreen(
                 CardDetailContent(
                     card = state.card!!,
                     account = state.account,
-                    onBlockClick = { viewModel.setEvent(CardDetailContract.UiEvent.ShowBlockDialog) }
+                    onBlockClick = { viewModel.setEvent(CardDetailContract.UiEvent.ShowBlockDialog) },
+                    onNavigateToCardHistory = onNavigateToCardHistory
                 )
             }
         }
@@ -163,7 +166,8 @@ fun CardDetailScreen(
 private fun CardDetailContent(
     card: CardResponseDto,
     account: AccountDetailsResponseDto?,
-    onBlockClick: () -> Unit
+    onBlockClick: () -> Unit,
+    onNavigateToCardHistory: (accountNumber: String, cardLabel: String) -> Unit
 ) {
     val animProgress = remember { Animatable(0f) }
     LaunchedEffect(Unit) {
@@ -231,6 +235,27 @@ private fun CardDetailContent(
                     InfoRow("Naziv racuna", account.nazivRacuna ?: "-")
                     InfoRow("Broj racuna", formatAccountNumber(account.brojRacuna ?: ""))
                     InfoRow("Valuta", account.currency ?: "-")
+                }
+            }
+
+            // History button
+            if (account?.brojRacuna != null) {
+                Button(
+                    onClick = {
+                        onNavigateToCardHistory(
+                            account.brojRacuna,
+                            formatMaskedCardNumber(card.cardNumber ?: "")
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.History,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Istorija transakcija po kartici")
                 }
             }
 

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/exchange/ExchangeScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/exchange/ExchangeScreen.kt
@@ -1,6 +1,11 @@
 package rs.raf.banka1.mobile.presentation.screens.exchange
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,12 +31,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -44,13 +54,13 @@ import java.text.NumberFormat
 import java.util.Locale
 
 private val currencyFlags = mapOf(
-    "EUR" to "\uD83C\uDDEA\uD83C\uDDFA",
-    "USD" to "\uD83C\uDDFA\uD83C\uDDF8",
-    "CHF" to "\uD83C\uDDE8\uD83C\uDDED",
-    "GBP" to "\uD83C\uDDEC\uD83C\uDDE7",
-    "JPY" to "\uD83C\uDDEF\uD83C\uDDF5",
-    "CAD" to "\uD83C\uDDE8\uD83C\uDDE6",
-    "AUD" to "\uD83C\uDDE6\uD83C\uDDFA"
+    "EUR" to "🇪🇺",
+    "USD" to "🇺🇸",
+    "CHF" to "🇨🇭",
+    "GBP" to "🇬🇧",
+    "JPY" to "🇯🇵",
+    "CAD" to "🇨🇦",
+    "AUD" to "🇦🇺"
 )
 
 private val currencyNames = mapOf(
@@ -62,6 +72,8 @@ private val currencyNames = mapOf(
     "CAD" to "Kanadski dolar",
     "AUD" to "Australijski dolar"
 )
+
+private val chartLineColor = Color(0xFF00897B)
 
 @Composable
 fun ExchangeScreen(
@@ -81,7 +93,6 @@ fun ExchangeScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        // Header
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -91,7 +102,7 @@ fun ExchangeScreen(
                 Icon(
                     imageVector = Icons.Default.CurrencyExchange,
                     contentDescription = null,
-                    tint = Color(0xFF00897B),
+                    tint = chartLineColor,
                     modifier = Modifier.size(28.dp)
                 )
                 Spacer(modifier = Modifier.width(12.dp))
@@ -121,7 +132,6 @@ fun ExchangeScreen(
                 )
             }
         } else {
-            // Table header
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -161,8 +171,26 @@ fun ExchangeScreen(
                 ) { index, rate ->
                     ExchangeRateRow(
                         rate = rate,
-                        isLast = index == state.rates.lastIndex
+                        isLast = index == state.rates.lastIndex,
+                        isSelected = rate.currencyCode == state.selectedCurrency,
+                        onClick = {
+                            rate.currencyCode?.let {
+                                viewModel.setEvent(ExchangeContract.UiEvent.SelectCurrency(it))
+                            }
+                        }
                     )
+                }
+
+                item {
+                    val selected = state.selectedCurrency
+                    if (selected != null) {
+                        Spacer(Modifier.height(16.dp))
+                        RateHistorySection(
+                            currencyCode = selected,
+                            points = state.historyPoints,
+                            isLoading = state.isLoadingHistory
+                        )
+                    }
                 }
 
                 item { Spacer(Modifier.height(24.dp)) }
@@ -174,7 +202,9 @@ fun ExchangeScreen(
 @Composable
 private fun ExchangeRateRow(
     rate: ExchangeRateDto,
-    isLast: Boolean
+    isLast: Boolean,
+    isSelected: Boolean,
+    onClick: () -> Unit
 ) {
     val code = rate.currencyCode ?: ""
     val rateFormatter = remember {
@@ -185,10 +215,17 @@ private fun ExchangeRateRow(
     }
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
         shape = if (isLast) RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
         else RoundedCornerShape(0.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isSelected)
+                chartLineColor.copy(alpha = 0.07f)
+            else
+                MaterialTheme.colorScheme.surface
+        ),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Row(
@@ -197,12 +234,22 @@ private fun ExchangeRateRow(
                 .padding(horizontal = 16.dp, vertical = 14.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Flag + currency info
+            if (isSelected) {
+                Box(
+                    modifier = Modifier
+                        .width(3.dp)
+                        .height(36.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(chartLineColor)
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+            }
+
             Box(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFF00897B).copy(alpha = 0.08f)),
+                    .background(chartLineColor.copy(alpha = 0.08f)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
@@ -238,6 +285,226 @@ private fun ExchangeRateRow(
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.width(80.dp)
             )
+        }
+    }
+}
+
+@Composable
+private fun RateHistorySection(
+    currencyCode: String,
+    points: List<ExchangeRateDto>,
+    isLoading: Boolean
+) {
+    val sortedPoints = remember(points) {
+        points.sortedBy { it.date ?: "" }
+    }
+    val values = remember(sortedPoints) {
+        sortedPoints.mapNotNull { it.sellingRate?.toFloat() }
+    }
+
+    val animProgress = remember(points) { Animatable(0f) }
+    LaunchedEffect(points) {
+        animProgress.snapTo(0f)
+        if (values.isNotEmpty()) {
+            animProgress.animateTo(1f, tween(600, easing = FastOutSlowInEasing))
+        }
+    }
+
+    val rateFormatter = remember {
+        NumberFormat.getNumberInstance(Locale("sr", "RS")).apply {
+            minimumFractionDigits = 2
+            maximumFractionDigits = 4
+        }
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "${currencyFlags[currencyCode] ?: ""} $currencyCode",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.weight(1f))
+                if (values.size >= 2) {
+                    val delta = values.last() - values.first()
+                    val deltaPercent = if (values.first() != 0f) delta / values.first() * 100f else 0f
+                    val deltaColor = if (delta >= 0) Color(0xFF388E3C) else Color(0xFFD32F2F)
+                    Text(
+                        text = "${if (delta >= 0) "+" else ""}${"%.2f".format(deltaPercent)}%",
+                        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                        color = deltaColor
+                    )
+                }
+            }
+            Text(
+                text = "Prodajni kurs — poslednjih 30 dana",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            when {
+                isLoading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(120.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(28.dp),
+                            strokeWidth = 2.dp,
+                            color = chartLineColor
+                        )
+                    }
+                }
+                values.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(80.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Nema podataka",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                else -> {
+                    val minVal = values.min()
+                    val maxVal = values.max()
+                    val range = (maxVal - minVal).coerceAtLeast(0.001f)
+
+                    Canvas(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(120.dp)
+                    ) {
+                        val w = size.width
+                        val h = size.height
+                        val padTop = 8.dp.toPx()
+                        val padBottom = 8.dp.toPx()
+                        val chartH = h - padTop - padBottom
+                        val n = values.size
+                        val stepX = if (n > 1) w / (n - 1).toFloat() else w
+
+                        fun xOf(i: Int) = i * stepX
+                        fun yOf(v: Float): Float {
+                            val normalized = (v - minVal) / range
+                            return padTop + chartH * (1f - normalized * animProgress.value)
+                        }
+
+                        // Grid lines
+                        val gridColor = Color.Gray.copy(alpha = 0.12f)
+                        for (g in 0..2) {
+                            val gy = padTop + g * chartH / 2f
+                            drawLine(gridColor, Offset(0f, gy), Offset(w, gy), strokeWidth = 0.5f)
+                        }
+
+                        // Fill area
+                        val fillPath = Path()
+                        fillPath.moveTo(xOf(0), h)
+                        values.forEachIndexed { i, v -> fillPath.lineTo(xOf(i), yOf(v)) }
+                        fillPath.lineTo(xOf(values.lastIndex), h)
+                        fillPath.close()
+                        drawPath(fillPath, color = chartLineColor.copy(alpha = 0.10f))
+
+                        // Line
+                        val linePath = Path()
+                        values.forEachIndexed { i, v ->
+                            val x = xOf(i)
+                            val y = yOf(v)
+                            if (i == 0) linePath.moveTo(x, y) else linePath.lineTo(x, y)
+                        }
+                        drawPath(
+                            linePath,
+                            color = chartLineColor,
+                            style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round)
+                        )
+
+                        // End dot (white border + teal fill)
+                        val lastX = xOf(values.lastIndex)
+                        val lastY = yOf(values.last())
+                        drawCircle(Color.White, radius = 5.dp.toPx(), center = Offset(lastX, lastY))
+                        drawCircle(chartLineColor, radius = 3.5f.dp.toPx(), center = Offset(lastX, lastY))
+                    }
+
+                    Spacer(Modifier.height(10.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column {
+                            Text(
+                                text = "Min",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = rateFormatter.format(values.min()),
+                                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                                color = Color(0xFFD32F2F)
+                            )
+                        }
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = "Poslednja vrednost",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = rateFormatter.format(values.last()),
+                                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text(
+                                text = "Max",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = rateFormatter.format(values.max()),
+                                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                                color = Color(0xFF388E3C)
+                            )
+                        }
+                    }
+
+                    if (sortedPoints.isNotEmpty()) {
+                        Spacer(Modifier.height(6.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = sortedPoints.first().date?.take(10) ?: "",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = sortedPoints.last().date?.take(10) ?: "",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/history/HistoryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ReceiptLong
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Payments
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.filled.SwapHoriz
@@ -34,6 +35,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -70,7 +72,8 @@ import kotlin.math.roundToInt
 fun HistoryScreen(
     viewModel: HistoryViewModel,
     onNavigateToTransferDetail: (orderNumber: String, fromCurrency: String, toCurrency: String) -> Unit,
-    onNavigateToTransactionDetail: (TransactionResponseDto) -> Unit
+    onNavigateToTransactionDetail: (TransactionResponseDto) -> Unit,
+    onClearFilter: () -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val onEvent = viewModel::setEvent
@@ -111,6 +114,14 @@ fun HistoryScreen(
                 text = "Pregled vasih transfera i transakcija",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        if (state.isFiltered) {
+            FilterBanner(
+                label = state.cardLabel ?: "",
+                onClear = onClearFilter,
+                modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp)
             )
         }
 
@@ -537,6 +548,39 @@ private fun TransactionRow(
                     )
                 }
             }
+        }
+    }
+}
+
+// --- Filter Banner ---
+
+@Composable
+private fun FilterBanner(
+    label: String,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Prikaz za karticu: $label",
+            style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.weight(1f)
+        )
+        IconButton(onClick = onClear, modifier = Modifier.size(24.dp)) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Ukloni filter",
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(16.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/loans/LoansScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/loans/LoansScreen.kt
@@ -1,0 +1,312 @@
+package rs.raf.banka1.mobile.presentation.screens.loans
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import rs.raf.banka1.mobile.data.remote.responses.LoanResponseDto
+import rs.raf.banka1.mobile.presentation.components.ErrorDialog
+import rs.raf.banka1.mobile.presentation.viewmodels.main.LoansContract
+import rs.raf.banka1.mobile.presentation.viewmodels.main.LoansViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LoansScreen(
+    viewModel: LoansViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    ErrorDialog(errorData = state.error) {
+        viewModel.setEvent(LoansContract.UiEvent.ClearError)
+    }
+
+    Scaffold { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(innerPadding)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onNavigateBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Nazad",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Default.AccountBalanceWallet,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = "Krediti",
+                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(32.dp),
+                        strokeWidth = 3.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                state.loans.isEmpty() -> LoansEmptyState()
+
+                else -> LazyColumn(
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(
+                        items = state.loans,
+                        key = { it.loanNumber ?: 0L }
+                    ) { loan ->
+                        LoanCard(
+                            loan = loan,
+                            isNext = loan.loanNumber != null && loan.loanNumber == state.soonestLoanNumber
+                        )
+                    }
+                    item { Spacer(Modifier.height(24.dp)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoanCard(loan: LoanResponseDto, isNext: Boolean) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = loanTypeLabel(loan.loanType),
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                LoanStatusChip(status = loan.status)
+            }
+
+            if (!loan.accountNumber.isNullOrBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = loan.accountNumber,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (loan.installmentAmount != null || loan.nextInstallmentDate != null) {
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(12.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Column {
+                        Text(
+                            text = "Sledeća rata",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (isNext) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            text = formatAmount(loan.installmentAmount),
+                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                            color = if (isNext) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurface
+                        )
+                        if (loan.nextInstallmentDate != null) {
+                            Text(
+                                text = formatDate(loan.nextInstallmentDate),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    if (isNext) {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(MaterialTheme.colorScheme.primaryContainer)
+                                .padding(horizontal = 8.dp, vertical = 4.dp)
+                        ) {
+                            Text(
+                                text = "Najskorija",
+                                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (loan.remainingDebt != null) {
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "Preostali dug",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = formatAmount(loan.remainingDebt),
+                        style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoanStatusChip(status: String?) {
+    val (bgColor, textColor) = when (status) {
+        "ACTIVE" -> Pair(
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer
+        )
+        "OVERDUE" -> Pair(
+            MaterialTheme.colorScheme.errorContainer,
+            MaterialTheme.colorScheme.onErrorContainer
+        )
+        "PAID_OFF" -> Pair(
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        else -> Pair(
+            MaterialTheme.colorScheme.surfaceVariant,
+            MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(bgColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = loanStatusLabel(status),
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+            color = textColor
+        )
+    }
+}
+
+@Composable
+private fun LoansEmptyState() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                imageVector = Icons.Default.AccountBalanceWallet,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.outlineVariant,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = "Nemate aktivnih kredita",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun loanTypeLabel(type: String?): String = when (type) {
+    "GOTOVINSKI" -> "Gotovinski"
+    "STAMBENI" -> "Stambeni"
+    "AUTO" -> "Auto"
+    "REFINANSIRAJUCI" -> "Refinansirajući"
+    "STUDENTSKI" -> "Studentski"
+    else -> type ?: "-"
+}
+
+private fun loanStatusLabel(status: String?): String = when (status) {
+    "PENDING" -> "Na čekanju"
+    "APPROVED" -> "Odobren"
+    "DECLINED" -> "Odbijen"
+    "ACTIVE" -> "Aktivan"
+    "OVERDUE" -> "U kašnjenju"
+    "PAID_OFF" -> "Otplaćen"
+    else -> status ?: "-"
+}
+
+private fun formatAmount(amount: Double?): String {
+    if (amount == null) return "-"
+    return String.format(java.util.Locale.US, "%.2f", amount) + " RSD"
+}
+
+private fun formatDate(date: String?): String {
+    if (date == null) return "-"
+    val parts = date.split("-")
+    return if (parts.size == 3) "${parts[2]}.${parts[1]}.${parts[0]}." else date
+}

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/notifications/NotificationsScreen.kt
@@ -23,10 +23,12 @@ import androidx.compose.material.icons.automirrored.filled.ReceiptLong
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -51,7 +53,8 @@ import java.util.Locale
 @Composable
 fun NotificationsScreen(
     viewModel: NotificationsViewModel,
-    onNavigateToOrders: () -> Unit
+    onNavigateToOrders: () -> Unit,
+    onNavigateToPriceAlerts: () -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val onEvent = viewModel::setEvent
@@ -80,6 +83,14 @@ fun NotificationsScreen(
                 color = MaterialTheme.colorScheme.onBackground,
                 modifier = Modifier.weight(1f)
             )
+            IconButton(onClick = onNavigateToPriceAlerts) {
+                Icon(
+                    imageVector = Icons.Default.NotificationsActive,
+                    contentDescription = "Cenovni alarmi",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
             if (state.notifications.any { !it.isRead }) {
                 TextButton(onClick = { onEvent(NotificationsContract.UiEvent.MarkAllRead) }) {
                     Icon(

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/notifications/NotificationsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ReceiptLong
+import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Notifications
@@ -189,8 +190,13 @@ private fun NotificationCard(
                     .background(accent.copy(alpha = 0.12f)),
                 contentAlignment = Alignment.Center
             ) {
+                val icon = when {
+                    notification.type == "ORDER_RECURRING_SKIPPED" -> Icons.Default.Autorenew
+                    notification.isRead -> Icons.Default.CheckCircle
+                    else -> Icons.Default.Notifications
+                }
                 Icon(
-                    imageVector = if (notification.isRead) Icons.Default.CheckCircle else Icons.Default.Notifications,
+                    imageVector = icon,
                     contentDescription = null,
                     tint = accent,
                     modifier = Modifier.size(22.dp)

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/notifications/NotificationsScreen.kt
@@ -136,7 +136,7 @@ fun NotificationsScreen(
                                 if (!notification.isRead) {
                                     onEvent(NotificationsContract.UiEvent.MarkRead(notification.id))
                                 }
-                                if (notification.orderId != null) {
+                                if (notification.orderId != null && notification.type != "ORDER_RECURRING_SKIPPED") {
                                     onNavigateToOrders()
                                 }
                             },

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/pricealerts/PriceAlertsScreen.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/screens/pricealerts/PriceAlertsScreen.kt
@@ -1,0 +1,427 @@
+package rs.raf.banka1.mobile.presentation.screens.pricealerts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.automirrored.filled.TrendingUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import rs.raf.banka1.mobile.data.remote.responses.ListingSummaryDto
+import rs.raf.banka1.mobile.presentation.components.ErrorDialog
+import rs.raf.banka1.mobile.presentation.viewmodels.main.PriceAlertsContract
+import rs.raf.banka1.mobile.presentation.viewmodels.main.PriceAlertsViewModel
+
+private val conditionOptions = listOf(
+    "ABOVE" to "Cena preko",
+    "BELOW" to "Cena ispod",
+    "PCT_DROP_INTRADAY" to "Intraday pad %"
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PriceAlertsScreen(
+    viewModel: PriceAlertsViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val onEvent = viewModel::setEvent
+
+    ErrorDialog(errorData = state.error) {
+        onEvent(PriceAlertsContract.UiEvent.ClearError)
+    }
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = { onEvent(PriceAlertsContract.UiEvent.OpenCreate) }) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "Dodaj alarm")
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(innerPadding)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onNavigateBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Nazad",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Spacer(Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Default.NotificationsActive,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = "Cenovni alarmi",
+                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            when {
+                state.isLoading -> Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(32.dp),
+                        strokeWidth = 3.dp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                state.alerts.isEmpty() -> AlertsEmptyState()
+
+                else -> LazyColumn(
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(items = state.alerts, key = { it.id }) { alert ->
+                        AlertCard(
+                            alert = alert,
+                            onToggle = { onEvent(PriceAlertsContract.UiEvent.Toggle(alert.id)) },
+                            onDelete = { onEvent(PriceAlertsContract.UiEvent.Delete(alert.id)) }
+                        )
+                    }
+                    item { Spacer(Modifier.height(80.dp)) }
+                }
+            }
+        }
+    }
+
+    if (state.showCreateSheet) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ModalBottomSheet(
+            onDismissRequest = { onEvent(PriceAlertsContract.UiEvent.DismissCreate) },
+            sheetState = sheetState
+        ) {
+            CreateAlertSheet(state = state, onEvent = onEvent)
+        }
+    }
+}
+
+@Composable
+private fun AlertCard(
+    alert: PriceAlertsContract.AlertUiModel,
+    onToggle: () -> Unit,
+    onDelete: () -> Unit
+) {
+    val conditionLabel = conditionOptions.find { it.first == alert.condition }?.second ?: alert.condition
+    val isPct = alert.condition == "PCT_DROP_INTRADAY"
+    val thresholdText = if (isPct) "${alert.threshold}%" else alert.threshold.toString()
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = alert.ticker?.takeIf { it.isNotBlank() } ?: "Listing #${alert.listingId}",
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (!alert.name.isNullOrBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = alert.name,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "$conditionLabel: $thresholdText",
+                    style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (!alert.createdAt.isNullOrBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = "Kreiran: ${alert.createdAt.take(10)}",
+                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                    )
+                }
+            }
+
+            Column(horizontalAlignment = Alignment.End) {
+                Switch(
+                    checked = alert.active,
+                    onCheckedChange = { onToggle() }
+                )
+                Spacer(Modifier.height(4.dp))
+                TextButton(onClick = onDelete) {
+                    Text("Obrisi", color = Color(0xFFEA4335), fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateAlertSheet(
+    state: PriceAlertsContract.UiState,
+    onEvent: (PriceAlertsContract.UiEvent) -> Unit
+) {
+    val isPct = state.condition == "PCT_DROP_INTRADAY"
+    val thresholdLabel = if (isPct) "Pad (%)" else "Prag (cena)"
+    val isValid = state.selectedListing != null &&
+            state.thresholdInput.toDoubleOrNull().let { it != null && it > 0.0 }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(horizontal = 24.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Text(
+            text = "Novi cenovni alarm",
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onBackground
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = state.searchQuery,
+            onValueChange = { onEvent(PriceAlertsContract.UiEvent.Search(it)) },
+            label = { Text("Pretrazi akcije") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+
+        if (state.searchResults.isNotEmpty()) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp),
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            ) {
+                Column {
+                    state.searchResults.take(6).forEach { listing ->
+                        ListingResultRow(listing = listing) {
+                            onEvent(PriceAlertsContract.UiEvent.SelectListing(listing))
+                        }
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+
+        state.selectedListing?.let { listing ->
+            Spacer(Modifier.height(8.dp))
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                    .padding(horizontal = 12.dp, vertical = 6.dp)
+            ) {
+                Text(
+                    text = "${listing.ticker ?: ""} — ${listing.name ?: ""}",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = "Uslov",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(6.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            conditionOptions.forEach { (value, label) ->
+                FilterChip(
+                    selected = state.condition == value,
+                    onClick = { onEvent(PriceAlertsContract.UiEvent.SetCondition(value)) },
+                    label = { Text(label, fontSize = 11.sp) }
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = state.thresholdInput,
+            onValueChange = { onEvent(PriceAlertsContract.UiEvent.SetThreshold(it)) },
+            label = { Text(thresholdLabel) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+        )
+
+        Spacer(Modifier.height(20.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextButton(onClick = { onEvent(PriceAlertsContract.UiEvent.DismissCreate) }) {
+                Text("Otkazi")
+            }
+            Spacer(Modifier.width(8.dp))
+            TextButton(
+                onClick = { onEvent(PriceAlertsContract.UiEvent.Submit) },
+                enabled = isValid && !state.isSubmitting
+            ) {
+                if (state.isSubmitting) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                } else {
+                    Text("Sacuvaj", fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun ListingResultRow(
+    listing: ListingSummaryDto,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.TrendingUp,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(Modifier.width(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = listing.ticker ?: "",
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            if (!listing.name.isNullOrBlank()) {
+                Text(
+                    text = listing.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        if (listing.price != null) {
+            Text(
+                text = "${listing.price} ${listing.currency ?: ""}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun AlertsEmptyState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                imageVector = Icons.Default.NotificationsActive,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.outlineVariant,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = "Nemate cenovnih alarma",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/AccountsCardsViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/AccountsCardsViewModel.kt
@@ -2,6 +2,8 @@ package rs.raf.banka1.mobile.presentation.viewmodels.main
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import rs.raf.banka1.mobile.data.apis.AccountApi
 import rs.raf.banka1.mobile.data.apis.CardApi
@@ -20,10 +22,6 @@ class AccountsCardsViewModel @Inject constructor(
     AccountsCardsContract.UiState()
 ) {
 
-    init {
-        loadData()
-    }
-
     override fun setEvent(event: AccountsCardsContract.UiEvent) {
         when (event) {
             is AccountsCardsContract.UiEvent.SelectTab -> setState { copy(selectedTab = event.tab) }
@@ -32,7 +30,7 @@ class AccountsCardsViewModel @Inject constructor(
         }
     }
 
-    private fun loadData() {
+    fun loadData() {
         viewModelScope.launch {
             setState { copy(isLoading = true, error = null) }
 
@@ -40,68 +38,57 @@ class AccountsCardsViewModel @Inject constructor(
                 is NetworkResult.Success -> {
                     val summaries = result.data.content
 
-                    // Fetch full account details (balance, embedded cards if backend provides them)
+                    // Fetch all account details in parallel
                     val accounts = summaries.map { summary ->
-                        val number = summary.brojRacuna ?: return@map summary
-                        when (val detail = accountApi.getAccountDetailsByNumber(number)) {
-                            is NetworkResult.Success -> detail.data
-                            else -> summary
+                        async {
+                            val number = summary.brojRacuna ?: return@async summary
+                            when (val detail = accountApi.getAccountDetailsByNumber(number)) {
+                                is NetworkResult.Success -> detail.data
+                                else -> summary
+                            }
                         }
-                    }
+                    }.awaitAll()
 
-                    // Index any cards the account-details endpoint already returned.
-                    // These carry the full CardResponseDto (id, status, cardType, expiryDate)
-                    // which is needed for the block feature.
-                    val detailedCardsByNumber: Map<String, CardResponseDto> = accounts
-                        .flatMap { it.cards ?: emptyList() }
-                        .filter { it.cardNumber != null }
-                        .associateBy { it.cardNumber!! }
-
-                    // Use CardApi as the definitive card list — it works even when the
-                    // account-details endpoint does not populate the cards field.
                     val clientId = accounts.firstOrNull()?.vlasnik
                     val cards: List<CardWithAccount> = if (clientId != null) {
-                        when (val cardResult = cardApi.getClientCards(clientId)) {
-                            is NetworkResult.Success -> cardResult.data.map { summary ->
-                                val account = accounts.find { it.brojRacuna == summary.accountNumber }
-                                // Prefer the enriched card from account-details (full info + id);
-                                // fall back to a minimal stub when account-details had no cards.
-                                val card = detailedCardsByNumber[summary.maskedCardNumber]
-                                    ?: CardResponseDto(
-                                        id = summary.id,
-                                        cardNumber = summary.maskedCardNumber,
-                                        accountNumber = summary.accountNumber
-                                    )
-                                CardWithAccount(
-                                    card = card,
-                                    accountName = account?.nazivRacuna
-                                        ?: account?.brojRacuna
-                                        ?: summary.accountNumber
-                                        ?: "",
-                                    accountId = clientId
-                                )
+                        when (val cardListResult = cardApi.getClientCards(clientId)) {
+                            is NetworkResult.Success -> {
+                                // Fetch full card details in parallel — gives us accurate status, type, expiry
+                                cardListResult.data.mapNotNull { summary ->
+                                    val id = summary.id ?: return@mapNotNull null
+                                    async {
+                                        val account = accounts.find { it.brojRacuna == summary.accountNumber }
+                                        val card = when (val r = cardApi.getCardById(id)) {
+                                            is NetworkResult.Success -> CardResponseDto(
+                                                id = r.data.id,
+                                                cardNumber = r.data.cardNumber,
+                                                cardType = r.data.cardType,
+                                                status = r.data.status,
+                                                expiryDate = r.data.expirationDate,
+                                                accountNumber = r.data.accountNumber
+                                            )
+                                            // If detail fetch fails, show card without status
+                                            else -> CardResponseDto(
+                                                id = summary.id,
+                                                cardNumber = summary.maskedCardNumber,
+                                                accountNumber = summary.accountNumber
+                                            )
+                                        }
+                                        CardWithAccount(
+                                            card = card,
+                                            accountName = account?.nazivRacuna
+                                                ?: account?.brojRacuna
+                                                ?: summary.accountNumber
+                                                ?: "",
+                                            accountId = clientId
+                                        )
+                                    }
+                                }.awaitAll()
                             }
-                            // CardApi failed — fall back to whatever account-details gave us
-                            else -> detailedCardsByNumber.values.map { card ->
-                                val account = accounts.find { it.brojRacuna == card.accountNumber }
-                                CardWithAccount(
-                                    card = card,
-                                    accountName = account?.nazivRacuna ?: account?.brojRacuna ?: "",
-                                    accountId = account?.vlasnik
-                                )
-                            }
+                            else -> emptyList()
                         }
                     } else {
-                        // No client ID available — use whatever account-details returned
-                        accounts.flatMap { account ->
-                            (account.cards ?: emptyList()).map { card ->
-                                CardWithAccount(
-                                    card = card,
-                                    accountName = account.nazivRacuna ?: account.brojRacuna ?: "",
-                                    accountId = account.vlasnik
-                                )
-                            }
-                        }
+                        emptyList()
                     }
 
                     setState { copy(isLoading = false, accounts = accounts, cards = cards) }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/AccountsCardsViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/AccountsCardsViewModel.kt
@@ -68,6 +68,7 @@ class AccountsCardsViewModel @Inject constructor(
                                 // fall back to a minimal stub when account-details had no cards.
                                 val card = detailedCardsByNumber[summary.maskedCardNumber]
                                     ?: CardResponseDto(
+                                        id = summary.id,
                                         cardNumber = summary.maskedCardNumber,
                                         accountNumber = summary.accountNumber
                                     )

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/AccountsCardsViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/AccountsCardsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import rs.raf.banka1.mobile.data.apis.AccountApi
+import rs.raf.banka1.mobile.data.apis.CardApi
 import rs.raf.banka1.mobile.data.remote.NetworkResult
 import rs.raf.banka1.mobile.data.remote.responses.AccountDetailsResponseDto
 import rs.raf.banka1.mobile.data.remote.responses.CardResponseDto
@@ -13,7 +14,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AccountsCardsViewModel @Inject constructor(
-    private val accountApi: AccountApi
+    private val accountApi: AccountApi,
+    private val cardApi: CardApi
 ) : BaseMviViewModel<AccountsCardsContract.UiState, AccountsCardsContract.UiEvent, AccountsCardsContract.SideEffect>(
     AccountsCardsContract.UiState()
 ) {
@@ -38,8 +40,7 @@ class AccountsCardsViewModel @Inject constructor(
                 is NetworkResult.Success -> {
                     val summaries = result.data.content
 
-                    // List endpoint returns AccountResponseDto (no cards).
-                    // Fetch full details (with cards) per account.
+                    // Fetch full account details (balance, embedded cards if backend provides them)
                     val accounts = summaries.map { summary ->
                         val number = summary.brojRacuna ?: return@map summary
                         when (val detail = accountApi.getAccountDetailsByNumber(number)) {
@@ -48,32 +49,65 @@ class AccountsCardsViewModel @Inject constructor(
                         }
                     }
 
-                    val cards = accounts.flatMap { account ->
-                        (account.cards ?: emptyList()).map { card ->
-                            CardWithAccount(
-                                card = card,
-                                accountName = account.nazivRacuna ?: account.brojRacuna ?: "",
-                                accountId = account.vlasnik
-                            )
+                    // Index any cards the account-details endpoint already returned.
+                    // These carry the full CardResponseDto (id, status, cardType, expiryDate)
+                    // which is needed for the block feature.
+                    val detailedCardsByNumber: Map<String, CardResponseDto> = accounts
+                        .flatMap { it.cards ?: emptyList() }
+                        .filter { it.cardNumber != null }
+                        .associateBy { it.cardNumber!! }
+
+                    // Use CardApi as the definitive card list — it works even when the
+                    // account-details endpoint does not populate the cards field.
+                    val clientId = accounts.firstOrNull()?.vlasnik
+                    val cards: List<CardWithAccount> = if (clientId != null) {
+                        when (val cardResult = cardApi.getClientCards(clientId)) {
+                            is NetworkResult.Success -> cardResult.data.map { summary ->
+                                val account = accounts.find { it.brojRacuna == summary.accountNumber }
+                                // Prefer the enriched card from account-details (full info + id);
+                                // fall back to a minimal stub when account-details had no cards.
+                                val card = detailedCardsByNumber[summary.maskedCardNumber]
+                                    ?: CardResponseDto(
+                                        cardNumber = summary.maskedCardNumber,
+                                        accountNumber = summary.accountNumber
+                                    )
+                                CardWithAccount(
+                                    card = card,
+                                    accountName = account?.nazivRacuna
+                                        ?: account?.brojRacuna
+                                        ?: summary.accountNumber
+                                        ?: "",
+                                    accountId = clientId
+                                )
+                            }
+                            // CardApi failed — fall back to whatever account-details gave us
+                            else -> detailedCardsByNumber.values.map { card ->
+                                val account = accounts.find { it.brojRacuna == card.accountNumber }
+                                CardWithAccount(
+                                    card = card,
+                                    accountName = account?.nazivRacuna ?: account?.brojRacuna ?: "",
+                                    accountId = account?.vlasnik
+                                )
+                            }
+                        }
+                    } else {
+                        // No client ID available — use whatever account-details returned
+                        accounts.flatMap { account ->
+                            (account.cards ?: emptyList()).map { card ->
+                                CardWithAccount(
+                                    card = card,
+                                    accountName = account.nazivRacuna ?: account.brojRacuna ?: "",
+                                    accountId = account.vlasnik
+                                )
+                            }
                         }
                     }
-                    setState {
-                        copy(
-                            isLoading = false,
-                            accounts = accounts,
-                            cards = cards
-                        )
-                    }
+
+                    setState { copy(isLoading = false, accounts = accounts, cards = cards) }
                 }
-                is NetworkResult.Error -> {
-                    setState { copy(isLoading = false, error = result.toErrorData()) }
-                }
-                is NetworkResult.Exception -> {
-                    setState { copy(isLoading = false, error = result.toErrorData()) }
-                }
-                is NetworkResult.Ignored -> {
-                    setState { copy(isLoading = false) }
-                }
+                is NetworkResult.Error -> setState { copy(isLoading = false, error = result.toErrorData()) }
+                is NetworkResult.Exception -> setState { copy(isLoading = false, error = result.toErrorData()) }
+                is NetworkResult.Ignored -> setState { copy(isLoading = false) }
             }
         }
     }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/CardDetailViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/CardDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import rs.raf.banka1.mobile.data.apis.AccountApi
 import rs.raf.banka1.mobile.data.apis.CardApi
@@ -44,26 +45,45 @@ class CardDetailViewModel @Inject constructor(
         viewModelScope.launch {
             setState { copy(isLoading = true, error = null) }
 
-            when (val result = accountApi.getAccountDetailsByNumber(route.accountNumber)) {
-                is NetworkResult.Success -> {
-                    val account = result.data
-                    val card = account.cards?.firstOrNull { it.cardNumber == route.cardNumber }
-                    setState {
-                        copy(
-                            isLoading = false,
-                            card = card,
-                            account = account
+            if (route.cardId > 0L) {
+                // Preferred path: fetch card directly by ID (avoids account-details cards:[] bug)
+                val cardDeferred = async { cardApi.getCardById(route.cardId) }
+                val accountDeferred = async { accountApi.getAccountDetailsByNumber(route.accountNumber) }
+
+                val cardResult = cardDeferred.await()
+                val accountResult = accountDeferred.await()
+
+                val account = (accountResult as? NetworkResult.Success)?.data
+
+                when (cardResult) {
+                    is NetworkResult.Success -> {
+                        val dto = cardResult.data
+                        // Map CardDetailDto → CardResponseDto so the existing screen composables work
+                        val card = CardResponseDto(
+                            id = dto.id,
+                            cardNumber = dto.cardNumber,
+                            cardType = dto.cardType,
+                            status = dto.status,
+                            expiryDate = dto.expirationDate,
+                            accountNumber = dto.accountNumber
                         )
+                        setState { copy(isLoading = false, card = card, account = account) }
                     }
+                    is NetworkResult.Error -> setState { copy(isLoading = false, error = cardResult.toErrorData()) }
+                    is NetworkResult.Exception -> setState { copy(isLoading = false, error = cardResult.toErrorData()) }
+                    is NetworkResult.Ignored -> setState { copy(isLoading = false) }
                 }
-                is NetworkResult.Error -> {
-                    setState { copy(isLoading = false, error = result.toErrorData()) }
-                }
-                is NetworkResult.Exception -> {
-                    setState { copy(isLoading = false, error = result.toErrorData()) }
-                }
-                is NetworkResult.Ignored -> {
-                    setState { copy(isLoading = false) }
+            } else {
+                // Fallback: try to find the card inside account-details (only works if backend populates it)
+                when (val result = accountApi.getAccountDetailsByNumber(route.accountNumber)) {
+                    is NetworkResult.Success -> {
+                        val account = result.data
+                        val card = account.cards?.firstOrNull { it.cardNumber == route.cardNumber }
+                        setState { copy(isLoading = false, card = card, account = account) }
+                    }
+                    is NetworkResult.Error -> setState { copy(isLoading = false, error = result.toErrorData()) }
+                    is NetworkResult.Exception -> setState { copy(isLoading = false, error = result.toErrorData()) }
+                    is NetworkResult.Ignored -> setState { copy(isLoading = false) }
                 }
             }
         }
@@ -81,15 +101,9 @@ class CardDetailViewModel @Inject constructor(
                     setState { copy(isBlocking = false, showBlockDialog = false) }
                     loadCard()
                 }
-                is NetworkResult.Error -> {
-                    setState { copy(isBlocking = false, showBlockDialog = false, error = result.toErrorData()) }
-                }
-                is NetworkResult.Exception -> {
-                    setState { copy(isBlocking = false, showBlockDialog = false, error = result.toErrorData()) }
-                }
-                is NetworkResult.Ignored -> {
-                    setState { copy(isBlocking = false, showBlockDialog = false) }
-                }
+                is NetworkResult.Error -> setState { copy(isBlocking = false, showBlockDialog = false, error = result.toErrorData()) }
+                is NetworkResult.Exception -> setState { copy(isBlocking = false, showBlockDialog = false, error = result.toErrorData()) }
+                is NetworkResult.Ignored -> setState { copy(isBlocking = false, showBlockDialog = false) }
             }
         }
     }

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/CardDetailViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/CardDetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import rs.raf.banka1.mobile.data.apis.AccountApi
+import rs.raf.banka1.mobile.data.apis.CardApi
 import rs.raf.banka1.mobile.data.remote.NetworkResult
 import rs.raf.banka1.mobile.data.remote.responses.AccountDetailsResponseDto
 import rs.raf.banka1.mobile.data.remote.responses.CardResponseDto
@@ -17,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CardDetailViewModel @Inject constructor(
     private val accountApi: AccountApi,
+    private val cardApi: CardApi,
     savedStateHandle: SavedStateHandle
 ) : BaseMviViewModel<CardDetailContract.UiState, CardDetailContract.UiEvent, CardDetailContract.SideEffect>(
     CardDetailContract.UiState()
@@ -32,6 +34,9 @@ class CardDetailViewModel @Inject constructor(
         when (event) {
             is CardDetailContract.UiEvent.Refresh -> loadCard()
             is CardDetailContract.UiEvent.ClearError -> setState { copy(error = null) }
+            is CardDetailContract.UiEvent.ShowBlockDialog -> setState { copy(showBlockDialog = true) }
+            is CardDetailContract.UiEvent.DismissBlockDialog -> setState { copy(showBlockDialog = false) }
+            is CardDetailContract.UiEvent.BlockCard -> blockCard()
         }
     }
 
@@ -63,6 +68,31 @@ class CardDetailViewModel @Inject constructor(
             }
         }
     }
+
+    private fun blockCard() {
+        val cardId = state.value.card?.id ?: run {
+            setState { copy(error = ErrorData(title = "Greška", message = "ID kartice nije dostupan.")) }
+            return
+        }
+        viewModelScope.launch {
+            setState { copy(isBlocking = true) }
+            when (val result = cardApi.blockCard(cardId)) {
+                is NetworkResult.Success -> {
+                    setState { copy(isBlocking = false, showBlockDialog = false) }
+                    loadCard()
+                }
+                is NetworkResult.Error -> {
+                    setState { copy(isBlocking = false, showBlockDialog = false, error = result.toErrorData()) }
+                }
+                is NetworkResult.Exception -> {
+                    setState { copy(isBlocking = false, showBlockDialog = false, error = result.toErrorData()) }
+                }
+                is NetworkResult.Ignored -> {
+                    setState { copy(isBlocking = false, showBlockDialog = false) }
+                }
+            }
+        }
+    }
 }
 
 interface CardDetailContract {
@@ -70,12 +100,17 @@ interface CardDetailContract {
         val isLoading: Boolean = false,
         val card: CardResponseDto? = null,
         val account: AccountDetailsResponseDto? = null,
-        val error: ErrorData? = null
+        val error: ErrorData? = null,
+        val showBlockDialog: Boolean = false,
+        val isBlocking: Boolean = false
     )
 
     sealed interface UiEvent {
         data object Refresh : UiEvent
         data object ClearError : UiEvent
+        data object ShowBlockDialog : UiEvent
+        data object DismissBlockDialog : UiEvent
+        data object BlockCard : UiEvent
     }
 
     sealed interface SideEffect

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/ExchangeViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/ExchangeViewModel.kt
@@ -10,6 +10,7 @@ import rs.raf.banka1.mobile.data.remote.NetworkResult
 import rs.raf.banka1.mobile.data.remote.responses.ExchangeRateDto
 import rs.raf.banka1.mobile.presentation.components.ErrorData
 import rs.raf.banka1.mobile.presentation.viewmodels.BaseMviViewModel
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,11 +23,13 @@ class ExchangeViewModel @Inject constructor(
 
     init {
         loadRates()
+        loadHistory("EUR")
     }
 
     override fun setEvent(event: ExchangeContract.UiEvent) {
         when (event) {
             is ExchangeContract.UiEvent.Refresh -> loadRates()
+            is ExchangeContract.UiEvent.SelectCurrency -> loadHistory(event.code)
         }
     }
 
@@ -37,7 +40,6 @@ class ExchangeViewModel @Inject constructor(
             when (val result = exchangeApi.getRates()) {
                 is NetworkResult.Success -> {
                     val rates = result.data.filter { it.currencyCode != "RSD" }
-                    // Cache locally
                     val entities = rates.mapNotNull { dto ->
                         val code = dto.currencyCode ?: return@mapNotNull null
                         ExchangeRateEntity(
@@ -51,7 +53,6 @@ class ExchangeViewModel @Inject constructor(
                     setState { copy(isLoading = false, rates = rates) }
                 }
                 is NetworkResult.Error -> {
-                    // Try cached
                     val cached = loadCached()
                     setState { copy(isLoading = false, rates = cached, error = result.toErrorData()) }
                 }
@@ -62,6 +63,20 @@ class ExchangeViewModel @Inject constructor(
                 is NetworkResult.Ignored -> {
                     setState { copy(isLoading = false) }
                 }
+            }
+        }
+    }
+
+    private fun loadHistory(code: String) {
+        viewModelScope.launch {
+            setState { copy(selectedCurrency = code, isLoadingHistory = true) }
+            val to = LocalDate.now()
+            val from = to.minusDays(30)
+            when (val result = exchangeApi.getRateHistory(code, from.toString(), to.toString())) {
+                is NetworkResult.Success -> setState { copy(isLoadingHistory = false, historyPoints = result.data) }
+                is NetworkResult.Error -> setState { copy(isLoadingHistory = false, historyPoints = emptyList()) }
+                is NetworkResult.Exception -> setState { copy(isLoadingHistory = false, historyPoints = emptyList()) }
+                is NetworkResult.Ignored -> setState { copy(isLoadingHistory = false) }
             }
         }
     }
@@ -84,11 +99,15 @@ interface ExchangeContract {
     data class UiState(
         val isLoading: Boolean = false,
         val rates: List<ExchangeRateDto> = emptyList(),
-        val error: ErrorData? = null
+        val error: ErrorData? = null,
+        val selectedCurrency: String? = "EUR",
+        val historyPoints: List<ExchangeRateDto> = emptyList(),
+        val isLoadingHistory: Boolean = false
     )
 
     sealed interface UiEvent {
         data object Refresh : UiEvent
+        data class SelectCurrency(val code: String) : UiEvent
     }
 
     sealed interface SideEffect

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/HistoryViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/HistoryViewModel.kt
@@ -1,6 +1,8 @@
 package rs.raf.banka1.mobile.presentation.viewmodels.main
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -14,6 +16,7 @@ import rs.raf.banka1.mobile.data.remote.responses.TransactionResponseDto
 import rs.raf.banka1.mobile.data.remote.responses.TransferResponseDto
 import rs.raf.banka1.mobile.data.repository.UserPreferencesRepository
 import rs.raf.banka1.mobile.presentation.components.ErrorData
+import rs.raf.banka1.mobile.presentation.navigation.Routes
 import rs.raf.banka1.mobile.presentation.viewmodels.BaseMviViewModel
 import javax.inject.Inject
 import kotlin.collections.flatten
@@ -22,13 +25,21 @@ import kotlin.collections.flatten
 class HistoryViewModel @Inject constructor(
     private val transferApi: TransferApi,
     private val transactionApi: TransactionApi,
-    private val accountApi: AccountApi, // Add AccountApi here
-    private val userPreferencesRepository: UserPreferencesRepository
+    private val accountApi: AccountApi,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    savedStateHandle: SavedStateHandle
 ) : BaseMviViewModel<HistoryContract.UiState, HistoryContract.UiEvent, HistoryContract.SideEffect>(
     HistoryContract.UiState()
 ) {
+    private val route = savedStateHandle.toRoute<Routes.MainFlow.History>()
 
     init {
+        setState {
+            copy(
+                cardLabel = route.cardLabel,
+                isFiltered = route.accountNumber != null
+            )
+        }
         loadData()
     }
 
@@ -41,6 +52,52 @@ class HistoryViewModel @Inject constructor(
     }
 
     private fun loadData() {
+        if (route.accountNumber != null) {
+            loadForAccount(route.accountNumber)
+        } else {
+            loadAllAccounts()
+        }
+    }
+
+    private fun loadForAccount(accountNumber: String) {
+        viewModelScope.launch {
+            setState { copy(isLoading = true, error = null) }
+
+            val transfersDeferred = async {
+                transferApi.getTransfersForAccount(accountNumber, 0, 100)
+            }
+            val transactionsDeferred = async {
+                transactionApi.getTransactionsForAccount(accountNumber, 0, 100)
+            }
+
+            val transfersResult = transfersDeferred.await()
+            val transactionsResult = transactionsDeferred.await()
+
+            val transfers = when (transfersResult) {
+                is NetworkResult.Success -> transfersResult.data.content
+                else -> emptyList()
+            }
+            val transactions = when (transactionsResult) {
+                is NetworkResult.Success -> transactionsResult.data.content
+                else -> emptyList()
+            }
+
+            val firstError = listOf(transfersResult, transactionsResult)
+                .filterIsInstance<NetworkResult.Error<*>>()
+                .firstOrNull()
+
+            setState {
+                copy(
+                    isLoading = false,
+                    transfers = transfers.sortedByDescending { it.timestamp ?: "" },
+                    transactions = transactions.sortedByDescending { it.createdAt ?: "" },
+                    error = firstError?.toErrorData()
+                )
+            }
+        }
+    }
+
+    private fun loadAllAccounts() {
         viewModelScope.launch {
             setState { copy(isLoading = true, error = null) }
 
@@ -49,46 +106,39 @@ class HistoryViewModel @Inject constructor(
                 setState {
                     copy(
                         isLoading = false,
-                        error = ErrorData(
-                            title = "Greska",
-                            message = "Nije moguce ucitati istoriju."
-                        )
+                        error = ErrorData(title = "Greska", message = "Nije moguce ucitati istoriju.")
                     )
                 }
                 return@launch
             }
 
-            // 1. Fetch Transfers
-            val transfers = when (val result = transferApi.getTransfers(clientId = clientId, page = 0, size = 100)) {
-                is NetworkResult.Success -> result.data.content
-                is NetworkResult.Error -> {
-                    setState { copy(isLoading = false, error = result.toErrorData()) }
-                    return@launch
-                }
-                is NetworkResult.Exception -> {
-                    setState { copy(isLoading = false, error = result.toErrorData()) }
-                    return@launch
-                }
-                is NetworkResult.Ignored -> {
-                    setState { copy(isLoading = false) }
-                    return@launch
-                }
+            val transfersDeferred = async {
+                transferApi.getTransfers(clientId = clientId, page = 0, size = 100)
+            }
+            val accountsDeferred = async {
+                accountApi.getMyAccounts(page = 0, size = 100)
             }
 
-            val accountsResult = accountApi.getMyAccounts(page = 0, size = 100)
-            val accountCurrencies = mutableMapOf<String, String>()
+            val transfersResult = transfersDeferred.await()
+            val accountsResult = accountsDeferred.await()
 
-            val transactions = when (accountsResult) {
+            val transfers = when (transfersResult) {
+                is NetworkResult.Success -> transfersResult.data.content
+                else -> emptyList()
+            }
+
+            val accountCurrencies = mutableMapOf<String, String>()
+            val transactions: List<TransactionResponseDto>
+
+            when (accountsResult) {
                 is NetworkResult.Success -> {
                     val accountNumbers = accountsResult.data.content.mapNotNull { account ->
-                        // Populate the currency map for later use!
                         if (account.brojRacuna != null && account.currency != null) {
                             accountCurrencies[account.brojRacuna] = account.currency
                         }
                         account.brojRacuna
                     }
 
-                    // 3. Fetch Transactions for all accounts concurrently
                     val deferredTransactions = accountNumbers.map { accountNumber ->
                         async {
                             transactionApi.getTransactionsForAccount(
@@ -99,31 +149,27 @@ class HistoryViewModel @Inject constructor(
                         }
                     }
 
-                    // Await all and flatten the successful results
-                    deferredTransactions.awaitAll().mapNotNull { result ->
-                        if (result is NetworkResult.Success) result.data.content else null
-                    }.flatten().distinctBy { it.orderNumber }
+                    transactions = deferredTransactions.awaitAll()
+                        .mapNotNull { result ->
+                            if (result is NetworkResult.Success) result.data.content else null
+                        }
+                        .flatten()
+                        .distinctBy { it.orderNumber }
                 }
-                is NetworkResult.Error -> {
-                    setState { copy(isLoading = false, error = accountsResult.toErrorData()) }
-                    return@launch
-                }
-                is NetworkResult.Exception -> {
-                    setState { copy(isLoading = false, error = accountsResult.toErrorData()) }
-                    return@launch
-                }
-                is NetworkResult.Ignored -> {
-                    setState { copy(isLoading = false) }
-                    return@launch
-                }
+                else -> transactions = emptyList()
             }
+
+            val firstError = listOf(transfersResult, accountsResult)
+                .filterIsInstance<NetworkResult.Error<*>>()
+                .firstOrNull()
 
             setState {
                 copy(
                     isLoading = false,
                     transfers = transfers.sortedByDescending { it.timestamp ?: "" },
                     transactions = transactions.sortedByDescending { it.createdAt ?: "" },
-                    accountCurrencies = accountCurrencies // Save the map to state!
+                    accountCurrencies = accountCurrencies,
+                    error = firstError?.toErrorData()
                 )
             }
         }
@@ -139,6 +185,8 @@ interface HistoryContract {
         val transfers: List<TransferResponseDto> = emptyList(),
         val transactions: List<TransactionResponseDto> = emptyList(),
         val accountCurrencies: Map<String, String> = emptyMap(),
+        val cardLabel: String? = null,
+        val isFiltered: Boolean = false,
         val error: ErrorData? = null
     )
 

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/LoansViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/LoansViewModel.kt
@@ -1,0 +1,83 @@
+package rs.raf.banka1.mobile.presentation.viewmodels.main
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import rs.raf.banka1.mobile.data.apis.LoanApi
+import rs.raf.banka1.mobile.data.remote.NetworkResult
+import rs.raf.banka1.mobile.data.remote.responses.LoanResponseDto
+import rs.raf.banka1.mobile.presentation.components.ErrorData
+import rs.raf.banka1.mobile.presentation.viewmodels.BaseMviViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class LoansViewModel @Inject constructor(
+    private val loanApi: LoanApi
+) : BaseMviViewModel<LoansContract.UiState, LoansContract.UiEvent, LoansContract.SideEffect>(
+    LoansContract.UiState()
+) {
+
+    init { loadLoans() }
+
+    override fun setEvent(event: LoansContract.UiEvent) {
+        when (event) {
+            is LoansContract.UiEvent.Refresh -> loadLoans()
+            is LoansContract.UiEvent.ClearError -> setState { copy(error = null) }
+        }
+    }
+
+    private fun loadLoans() {
+        viewModelScope.launch {
+            setState { copy(isLoading = true, error = null) }
+            when (val result = loanApi.getClientLoans()) {
+                is NetworkResult.Success -> {
+                    val sorted = result.data.content.sortedWith(Comparator { a, b ->
+                        val aDate = a.nextInstallmentDate
+                        val bDate = b.nextInstallmentDate
+                        when {
+                            aDate == null && bDate == null -> 0
+                            aDate == null -> 1
+                            bDate == null -> -1
+                            else -> aDate.compareTo(bDate)
+                        }
+                    })
+                    val soonestLoanNumber = sorted.firstOrNull {
+                        it.status == "ACTIVE" && it.nextInstallmentDate != null
+                    }?.loanNumber
+                    setState {
+                        copy(
+                            isLoading = false,
+                            loans = sorted,
+                            soonestLoanNumber = soonestLoanNumber
+                        )
+                    }
+                }
+                is NetworkResult.Error -> {
+                    setState { copy(isLoading = false, error = result.toErrorData()) }
+                }
+                is NetworkResult.Exception -> {
+                    setState { copy(isLoading = false, error = result.toErrorData()) }
+                }
+                is NetworkResult.Ignored -> {
+                    setState { copy(isLoading = false) }
+                }
+            }
+        }
+    }
+}
+
+interface LoansContract {
+    data class UiState(
+        val isLoading: Boolean = false,
+        val loans: List<LoanResponseDto> = emptyList(),
+        val soonestLoanNumber: Long? = null,
+        val error: ErrorData? = null
+    )
+
+    sealed interface UiEvent {
+        data object Refresh : UiEvent
+        data object ClearError : UiEvent
+    }
+
+    sealed interface SideEffect
+}

--- a/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/PriceAlertsViewModel.kt
+++ b/app/src/main/java/rs/raf/banka1/mobile/presentation/viewmodels/main/PriceAlertsViewModel.kt
@@ -1,0 +1,222 @@
+package rs.raf.banka1.mobile.presentation.viewmodels.main
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import rs.raf.banka1.mobile.data.apis.ListingApi
+import rs.raf.banka1.mobile.data.apis.PriceAlertApi
+import rs.raf.banka1.mobile.data.remote.NetworkResult
+import rs.raf.banka1.mobile.data.remote.requests.CreatePriceAlertRequest
+import rs.raf.banka1.mobile.data.remote.responses.ListingSummaryDto
+import rs.raf.banka1.mobile.presentation.components.ErrorData
+import rs.raf.banka1.mobile.presentation.viewmodels.BaseMviViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PriceAlertsViewModel @Inject constructor(
+    private val priceAlertApi: PriceAlertApi,
+    private val listingApi: ListingApi
+) : BaseMviViewModel<PriceAlertsContract.UiState, PriceAlertsContract.UiEvent, PriceAlertsContract.SideEffect>(
+    PriceAlertsContract.UiState()
+) {
+
+    init {
+        setEvent(PriceAlertsContract.UiEvent.Load)
+    }
+
+    override fun setEvent(event: PriceAlertsContract.UiEvent) {
+        when (event) {
+            is PriceAlertsContract.UiEvent.Load -> loadAlerts()
+            is PriceAlertsContract.UiEvent.OpenCreate -> setState { copy(showCreateSheet = true) }
+            is PriceAlertsContract.UiEvent.DismissCreate -> setState {
+                copy(
+                    showCreateSheet = false,
+                    searchQuery = "",
+                    searchResults = emptyList(),
+                    selectedListing = null,
+                    condition = "ABOVE",
+                    thresholdInput = "",
+                    isSubmitting = false
+                )
+            }
+            is PriceAlertsContract.UiEvent.Search -> onSearch(event.q)
+            is PriceAlertsContract.UiEvent.SelectListing -> setState {
+                copy(selectedListing = event.dto, searchQuery = event.dto.ticker ?: "", searchResults = emptyList())
+            }
+            is PriceAlertsContract.UiEvent.SetCondition -> setState { copy(condition = event.c) }
+            is PriceAlertsContract.UiEvent.SetThreshold -> setState { copy(thresholdInput = event.s) }
+            is PriceAlertsContract.UiEvent.Submit -> submit()
+            is PriceAlertsContract.UiEvent.Toggle -> toggleAlert(event.id)
+            is PriceAlertsContract.UiEvent.Delete -> deleteAlert(event.id)
+            is PriceAlertsContract.UiEvent.ClearError -> setState { copy(error = null) }
+        }
+    }
+
+    private fun loadAlerts() {
+        viewModelScope.launch {
+            setState { copy(isLoading = true, error = null) }
+            when (val result = priceAlertApi.getMyAlerts()) {
+                is NetworkResult.Success -> {
+                    val models = result.data.map { dto ->
+                        PriceAlertsContract.AlertUiModel(
+                            id = dto.id ?: 0L,
+                            listingId = dto.listingId ?: 0L,
+                            condition = dto.condition ?: "",
+                            threshold = dto.threshold ?: 0.0,
+                            active = dto.active,
+                            createdAt = dto.createdAt,
+                            ticker = null,
+                            name = null
+                        )
+                    }
+                    setState { copy(alerts = models, isLoading = false) }
+                    enrichAlerts(models)
+                }
+                is NetworkResult.Error -> setState {
+                    copy(isLoading = false, error = result.toErrorData())
+                }
+                is NetworkResult.Exception -> setState {
+                    copy(isLoading = false, error = result.toErrorData())
+                }
+                is NetworkResult.Ignored -> setState { copy(isLoading = false) }
+            }
+        }
+    }
+
+    private fun enrichAlerts(models: List<PriceAlertsContract.AlertUiModel>) {
+        val distinctIds = models.map { it.listingId }.distinct()
+        distinctIds.forEach { listingId ->
+            viewModelScope.launch {
+                val result = listingApi.getDetails(listingId, "DAY")
+                if (result is NetworkResult.Success) {
+                    val details = result.data
+                    setState {
+                        copy(alerts = alerts.map { alert ->
+                            if (alert.listingId == listingId) {
+                                alert.copy(ticker = details.ticker, name = details.name)
+                            } else alert
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onSearch(q: String) {
+        setState { copy(searchQuery = q) }
+        if (q.length < 1) {
+            setState { copy(searchResults = emptyList()) }
+            return
+        }
+        viewModelScope.launch {
+            when (val result = listingApi.searchStocks(q = q)) {
+                is NetworkResult.Success -> setState { copy(searchResults = result.data.content) }
+                else -> {}
+            }
+        }
+    }
+
+    private fun submit() {
+        val s = state.value
+        val listing = s.selectedListing ?: return
+        val threshold = s.thresholdInput.toDoubleOrNull()
+        if (threshold == null || threshold <= 0.0) return
+
+        viewModelScope.launch {
+            setState { copy(isSubmitting = true) }
+            val req = CreatePriceAlertRequest(
+                listingId = listing.listingId ?: return@launch,
+                condition = s.condition,
+                threshold = threshold,
+                notificationType = "PUSH"
+            )
+            when (val result = priceAlertApi.create(req)) {
+                is NetworkResult.Success -> {
+                    setEvent(PriceAlertsContract.UiEvent.DismissCreate)
+                    loadAlerts()
+                }
+                is NetworkResult.Error -> setState {
+                    copy(isSubmitting = false, error = result.toErrorData())
+                }
+                is NetworkResult.Exception -> setState {
+                    copy(isSubmitting = false, error = result.toErrorData())
+                }
+                is NetworkResult.Ignored -> setState { copy(isSubmitting = false) }
+            }
+        }
+    }
+
+    private fun toggleAlert(id: Long) {
+        viewModelScope.launch {
+            when (val result = priceAlertApi.toggle(id)) {
+                is NetworkResult.Success -> {
+                    val updated = result.data
+                    setState {
+                        copy(alerts = alerts.map { alert ->
+                            if (alert.id == id) alert.copy(active = updated.active) else alert
+                        })
+                    }
+                }
+                is NetworkResult.Error -> setState { copy(error = result.toErrorData()) }
+                is NetworkResult.Exception -> setState { copy(error = result.toErrorData()) }
+                is NetworkResult.Ignored -> {}
+            }
+        }
+    }
+
+    private fun deleteAlert(id: Long) {
+        viewModelScope.launch {
+            when (val result = priceAlertApi.delete(id)) {
+                is NetworkResult.Success -> setState {
+                    copy(alerts = alerts.filter { it.id != id })
+                }
+                is NetworkResult.Error -> setState { copy(error = result.toErrorData()) }
+                is NetworkResult.Exception -> setState { copy(error = result.toErrorData()) }
+                is NetworkResult.Ignored -> {}
+            }
+        }
+    }
+}
+
+interface PriceAlertsContract {
+
+    data class UiState(
+        val alerts: List<AlertUiModel> = emptyList(),
+        val isLoading: Boolean = true,
+        val error: ErrorData? = null,
+        val showCreateSheet: Boolean = false,
+        val searchQuery: String = "",
+        val searchResults: List<ListingSummaryDto> = emptyList(),
+        val selectedListing: ListingSummaryDto? = null,
+        val condition: String = "ABOVE",
+        val thresholdInput: String = "",
+        val isSubmitting: Boolean = false
+    )
+
+    data class AlertUiModel(
+        val id: Long,
+        val listingId: Long,
+        val condition: String,
+        val threshold: Double,
+        val active: Boolean,
+        val createdAt: String?,
+        val ticker: String?,
+        val name: String?
+    )
+
+    sealed interface UiEvent {
+        data object Load : UiEvent
+        data object OpenCreate : UiEvent
+        data object DismissCreate : UiEvent
+        data class Search(val q: String) : UiEvent
+        data class SelectListing(val dto: ListingSummaryDto) : UiEvent
+        data class SetCondition(val c: String) : UiEvent
+        data class SetThreshold(val s: String) : UiEvent
+        data object Submit : UiEvent
+        data class Toggle(val id: Long) : UiEvent
+        data class Delete(val id: Long) : UiEvent
+        data object ClearError : UiEvent
+    }
+
+    sealed interface SideEffect
+}


### PR DESCRIPTION
## Summary

- **Issue 5 & 7** — My Orders screen (paginated order list) and order lifecycle FCM push notifications (ORDER_CREATED, ORDER_DONE, ORDER_PARTIAL_FILL, ORDER_AUTO_CANCELLED) with in-app inbox
- **Issue 6** — Price Alert management screen (list, create, toggle active, delete via `/price-alerts`) and FCM inbox handling for `PRICE_ALERT_TRIGGERED` events
- **Issue 10 (receive-side)** — `ORDER_RECURRING_SKIPPED` FCM event handling: distinct fallback title/body text when FCM fields are blank, and `Autorenew` icon in the inbox row to visually distinguish skipped recurring orders; no new consumer branch needed — existing `startsWith("ORDER_")` path already catches this event type

## Key decisions

- `ORDER_RECURRING_SKIPPED` `orderId`/`ticker`/`status` FCM fields are null by design (backend sends them only in template variables, not as top-level payload keys). The existing `toLongOrNull()` path already handles null orderId safely; clicking a null-orderId notification stays on the inbox screen rather than navigating to orders.
- No new consumer branch in `BankMessagingService` — the frozen contract from the shared session plan is honoured.

## Test plan

- [ ] Trigger an `ORDER_RECURRING_SKIPPED` FCM push; confirm inbox row appears with readable title/body and the Autorenew icon
- [ ] Confirm tapping a recurring-skipped row marks it read but does NOT navigate to the Orders screen (orderId is null)
- [ ] Confirm existing ORDER_DONE / ORDER_CREATED rows still show the correct Notifications/CheckCircle icon
- [ ] Confirm price alert rows (PRICE_ALERT_TRIGGERED) still display and toggle correctly
- [ ] `./gradlew :app:assembleDebug` passes